### PR TITLE
#4 Changed Dataframe little bit more Pandas style

### DIFF
--- a/src/PandasNET/DataFrame.cs
+++ b/src/PandasNET/DataFrame.cs
@@ -1,7 +1,9 @@
 ﻿using NumSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Dynamic;
 
 namespace PandasNET
 {
@@ -9,15 +11,49 @@ namespace PandasNET
     /// Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns).
     /// https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html
     /// </summary>
-    public class DataFrame<T> : NDArray<T>
+    public class DataFrame<TIndex,TData> 
     {
         public DataFrame()
         {
-            Columns = new Index();
+            _ColumnArrayMapping = new Dictionary<string, NDArray<TData>>();
+            Columns = new Index<string>();
+            Columns.Values = new NDArray<string>();
+            Columns.Values.Data = null;
         }
+        public NDArray<TData> this[string column]
+        {
+            get 
+            {
+                return (_ColumnArrayMapping[column]);
+            }
+            set
+            {
+                if (!_ColumnArrayMapping.ContainsKey(column))
+                {
+                    if (Columns.Values.Data == null)
+                    {
+                        Columns.Values.Data = new string[]{ column};
+                        Columns.Values.Shape = new Shape(1); 
+                    }    
+                    else
+                    {
+                        var puffer = Columns.Values.Data.ToList();
+                        puffer.Add(column);
+                        Columns.Values.Data = puffer.ToArray();
+                        Columns.Values.Shape = new Shape( puffer.Count );
+                    } 
+                }
+                else 
+                {
 
-        public Index Columns { get; set; }
-
-        public NDArray<T> Values { get; set; }
+                }
+                    
+                _ColumnArrayMapping[column] = value;
+            }
+        } 
+        protected Dictionary<string,NDArray<TData>> _ColumnArrayMapping;
+        public Index<TIndex> Index {get;set;}
+        public Index<string> Columns {get;set;}
+        public NDArray<TData> Values { get; set; }
     }
 }

--- a/src/PandasNET/Extensions/Pandas.DataFrame.cs
+++ b/src/PandasNET/Extensions/Pandas.DataFrame.cs
@@ -2,20 +2,62 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace PandasNET.Extensions
 {
     public static partial class PandasExtensions
     {
-        public static DataFrame<T> DataFrame<T>(this Pandas pd, NDArray<T> data, IList<int> index = null, IList<string> columns = null)
+        public static DataFrame<TInd,TValue> DataFrame<TInd,TValue>(this Pandas pd, NDArray<TValue>[] data, IList<TInd> index = null, IList<string> columns = null)
         {
-            var df = new DataFrame<T>();
-            df.Columns.Array(columns);
-            df.Data = data.Data;
-            df.Shape = data.Shape;
+            var df = new DataFrame<TInd,TValue>();
+
+            if (columns == null)
+                columns = Enumerable.Range(0,(data.Length-1)).Select(x => x.ToString()).ToArray();
+
+            Type indexType = typeof(TInd);
+
+            if (index == null)
+            {
+                dynamic indexDyn = index;
+                switch (indexType.Name)
+                {
+                    case ("Double"): indexDyn = Enumerable.Range(0,data[0].Data.Length).Select(x => (double) x).ToList()  ; break;
+                    case ("Int32"): indexDyn = Enumerable.Range(0,data[0].Data.Length).ToList()  ; break;
+                }
+                index = (List<TInd>) indexDyn; 
+            }
+            else 
+            {
+
+            }
+
+            for(int idx = 0; idx < columns.Count;idx++)
+                df[columns[idx]] = data[idx];
+        
+            df.Index = new Index<TInd>();
+            df.Index.Values = new NDArray<TInd>();
+            df.Index.Values.Data = index.ToArray();
+            df.Index.Values.Shape = new Shape(index.Count);
 
             return df;
+        }
+        public static DataFrame<TInd,TValue> DataFrame<TInd,TValue>(this Pandas pd, NDArray<TValue> data, IList<TInd> index = null, IList<string> columns = null)
+        {
+
+            var vectors = new NDArray<TValue>[data.Shape.Shapes[1]];
+            
+            for (int idx = 0;idx < data.Shape.Shapes[1];idx++)
+            {
+                vectors[idx] = new NDArray<TValue>();
+                vectors[idx].Data = new TValue[data.Shape.Shapes[0]];
+                for (int jdx = 0; jdx < data.Shape.Shapes[0];jdx++)
+                {
+                    vectors[idx].Data[jdx] = data[jdx,idx];
+                }
+            } 
+            return pd.DataFrame<TInd,TValue>(vectors,index,columns);
         }
     }
 }

--- a/src/PandasNET/Extensions/Pandas.ReadCsv.cs
+++ b/src/PandasNET/Extensions/Pandas.ReadCsv.cs
@@ -9,7 +9,8 @@ namespace PandasNET.Extensions
 {
     public static partial class PandasExtensions
     {
-        public static DataFrame<double> read_csv(this Pandas pd, string filepath_or_buffer, string sep = ",")
+        
+        public static DataFrame<int,double> read_csv(this Pandas pd, string filepath_or_buffer, string sep = ",")
         {
             var data = new List<double[]>();
             var columns = new List<string>();
@@ -32,9 +33,10 @@ namespace PandasNET.Extensions
             }
 
             var nd = new NumPy<double>().array(data.ToArray());
-            var df = pd.DataFrame(nd, columns: columns);
+            var df = pd.DataFrame<int,double>(nd, columns: columns);
 
             return df;
         }
+        
     }
 }

--- a/src/PandasNET/Index.cs
+++ b/src/PandasNET/Index.cs
@@ -2,11 +2,16 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using PandasNET;
 
 namespace PandasNET
 {
-    public class Index : NDArray<string>
+    public class Index<T>
     {
-        public NDArray<string> Values { get; set; }
+        public Index()
+        {
+            
+        }   
+        public NDArray<T> Values { get; set; } 
     }
 }

--- a/test/PandasNET.UnitTest/Extensions/Pandas.DataFrame.Test.cs
+++ b/test/PandasNET.UnitTest/Extensions/Pandas.DataFrame.Test.cs
@@ -17,7 +17,17 @@ namespace PandasNET.UnitTest.Extensions
             var np = new NumPy<int>();
             var pd = new Pandas();
             var array = np.random.randint(low: 0, high: 10, size: new Shape(5, 5));
-            var df = pd.DataFrame(array, columns: new string[] { "a", "b", "c", "d", "e" });
+            var df = pd.DataFrame<int,int>(array, columns: new string[] { "a", "b", "c", "d", "e" });
+
+            var column1 = df["a"];
+
+            for (int idx = 0; idx < 5; idx++)
+                Assert.IsTrue(column1[idx] == array[idx,0]);
+
+            var column2 = df["b"];
+
+            for (int idx = 0; idx < 5; idx++)
+                Assert.IsTrue(column2[idx] == array[idx,1]);
         }
     }
 }

--- a/test/PandasNET.UnitTest/Extensions/Pandas.ReadCsv.Test.cs
+++ b/test/PandasNET.UnitTest/Extensions/Pandas.ReadCsv.Test.cs
@@ -13,7 +13,16 @@ namespace PandasNET.UnitTest.Extensions
         public void read_csv()
         {
             var pd = new Pandas();
-            var a = pd.read_csv("./data/train.csv");
+
+            var trainData = System.IO.Path.GetFullPath("../../../../../data/train.csv");
+
+            var a = pd.read_csv(trainData);
+
+            var column1 = a["Lag1"];
+            var column2 = a["Lag2"];
+
+            Assert.IsTrue(column1.Size == 998);
+            Assert.IsTrue(column2.Size == 998);
         }
     }
 }


### PR DESCRIPTION
- corresponding to #4 
- be careful! there are a lot of changes
- before you accept the request --> check the project separately maybe (https://github.com/dotChris90/Pandas.NET/tree/issue4) 
- the DataFrame class must contain 2 Generic types for the index type and value types
- index type can be int, double, datetime, string (really everything if you look pandas in python)
- value type is like in NDArray<TData> 
- Index must also be generic because it can be int, double, string and datetype (in python they write classes for this Datetimeindexclass, integerindexclass, ... we should use generics because this is C# strength)
- since datas (columns) are accessed like column1 = df['column1'] I suggest we use a internal protected Dictionary (NDArray uses array for storage, dataframe shall use dictionary)
- To verify all I adapted the unit Tests (they work - thats why i push ;) )  
